### PR TITLE
feat: Implement DELETE API for records

### DIFF
--- a/apps/backend/src/api/v1/records.py
+++ b/apps/backend/src/api/v1/records.py
@@ -73,3 +73,22 @@ async def update_record_endpoint(
             status_code=404, detail='Workout record not found to update'
         )
     return updated_record
+
+
+@router.delete('/{record_id}', response_model=RecordRead, status_code=status.HTTP_200_OK)
+async def delete_record_endpoint(
+    record_id: int,
+    db: AsyncSession = Depends(get_session),
+):
+    """
+    指定されたIDのトレーニング記録を削除する。
+    成功した場合は削除された記録オブジェクトを返す。
+    記録が見つからない場合は404エラーを返す。
+    """
+    deleted_record = await record_service.delete_record(db=db, record_id=record_id)
+    if deleted_record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='Workout record not found to delete',
+        )
+    return deleted_record

--- a/apps/backend/src/services/record_service.py
+++ b/apps/backend/src/services/record_service.py
@@ -83,3 +83,16 @@ async def update_record(
     await db.refresh(db_record)  # DBから最新情報を再読み込み
 
     return db_record
+
+
+async def delete_record(db: AsyncSession, record_id: int) -> Optional[WorkoutRecord]:
+    """
+    指定されたIDのトレーニング記録をデータベースから削除する。
+    成功した場合は削除されたレコードオブジェクトを、見つからない場合はNoneを返す。
+    """
+    record_object = await get_record(db=db, record_id=record_id)
+    if record_object:
+        await db.delete(record_object)
+        await db.commit()
+        return record_object
+    return None


### PR DESCRIPTION
Adds a new DELETE API endpoint `/api/v1/records/{record_id}` to allow deletion of workout records.

The implementation follows a TDD approach:
- A `delete_record` service function was added to `record_service.py` to handle the database deletion logic.
- Unit tests for the `delete_record` service function were added to `test_records.py`, covering successful deletion and attempting to delete non-existent records.
- The DELETE API endpoint was added to `api/v1/records.py`, calling the new service function and returning the deleted record or a 404 error.
- API tests for the new endpoint were added to `test_records.py`, covering successful deletion (200 OK response) and attempting to delete a non-existent record (404 Not Found response).

All new functions and tests include Japanese docstrings for consistency with the existing codebase.